### PR TITLE
Fix SAP Profile Update - Updating instance profile

### DIFF
--- a/roles/sap_profile_update/tasks/main.yml
+++ b/roles/sap_profile_update/tasks/main.yml
@@ -34,4 +34,4 @@
   loop_control:
     loop_var: passed_parameter
   when:
-    - sap_update_profile_default_profile_params is defined
+    - sap_update_profile_instance_profile_params is defined


### PR DESCRIPTION
This commit fixes the condition of SAP profile Update, to update the
instance profile in case there is
sap_update_profile_instance_profile_params defined.

Signed-off-by: Ondra Machacek <omachace@redhat.com>