### PR TITLE
solution to issue#25

### DIFF
--- a/roles/sap_control/tasks/main.yml
+++ b/roles/sap_control/tasks/main.yml
@@ -87,12 +87,13 @@
 # Get SAP Facts
 - name: Run sap_facts module to gather SAP facts
   community.sap_libs.sap_system_facts:
-    param: "{{ sap_facts_param }}"
+    # param: "{{ sap_facts_param }}"
   register: sap_facts_register
 
-- name: Debug facts
+- name: Debug result from sap_libs.sap_system_facts
   ansible.builtin.debug:
-    msg: "{{ sap_facts_register.sap_facts }}"
+    msg: "{{ sap_facts_register.ansible_facts.sap }}"
+    verbosity: 1
 
 - name: pause for 10 Seconds
   ansible.builtin.pause:

--- a/roles/sap_control/tasks/prepare.yml
+++ b/roles/sap_control/tasks/prepare.yml
@@ -13,9 +13,9 @@
   vars:
     sap_control_execute_sid: "{{ item.SID }}"
     sap_control_execute_type: "{{ item.Type }}"
-    sap_control_execute_instance_nr: "{{ item.InstanceNumber }}"
+    sap_control_execute_instance_nr: "{{ item.NR }}"
     sap_control_execute_instance_type: "{{ item.InstanceType }}"
   ansible.builtin.include_tasks: "sapcontrol.yml"
-  loop: "{{ sap_facts_register.sap_facts }}"
+  loop: "{{ sap_facts_register.ansible_facts.sap }}"
   when:
-    - "item.Type == sap_type"
+    - "item.InstanceType | lower == sap_type | lower"


### PR DESCRIPTION
Please check my solution to the [issue#25](https://github.com/sap-linuxlab/community.sap_operations/issues/25) in role sap_control.

The solution adopts to the namespace (ansible_facts.sap instead of sap_facts) when calling the module 
community.sap_libs.sap_system_facts from the playbook tasks/main.yml.
It also corrects the names of variables that are used in tasks/prepare.yml used in the call of the playbook tasks/sapcontrol.yml.

