### PR TITLE
Replace ansible.builtin.pause with ansible.builtin.wait_for

### DIFF
--- a/roles/sap_control/tasks/functions/restart_sapstartsrv.yml
+++ b/roles/sap_control/tasks/functions/restart_sapstartsrv.yml
@@ -33,5 +33,5 @@
   register: sap_start_sapstartsrv
 
 - name: SAPstartsrv - Wait for 10 seconds for sapstartsrv to initialize
-  ansible.builtin.pause:
-    seconds: 10
+  ansible.builtin.wait_for:
+    timeout: 10

--- a/roles/sap_control/tasks/main.yml
+++ b/roles/sap_control/tasks/main.yml
@@ -95,8 +95,8 @@
     msg: "{{ sap_facts_register.sap_facts }}"
 
 - name: pause for 10 Seconds
-  ansible.builtin.pause:
-    seconds: 10
+  ansible.builtin.wait_for:
+    timeout: 10
 
 # Debugging stuff
 - name: Display parameters for runtime


### PR DESCRIPTION
This fixes an issue when running with strategy free:
> ERROR! The 'ansible.builtin.pause' module bypasses the host loop, which
> is currently not supported in the free strategy and would instead
> execute for every host in the inventory list.

Furthermore, the documentation for ansible.builtin.pause states: To pause/wait/sleep per host, use the ansible.builtin.wait_for module.

See https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pause_module.html