### PR TITLE
Bugfix on failing restart due to wrong sorted SAP instance types

### DIFF
--- a/roles/sap_control/tasks/prepare.yml
+++ b/roles/sap_control/tasks/prepare.yml
@@ -4,6 +4,7 @@
   ansible.builtin.set_fact:
     sap_type: "{{ function_list.sap_control_function_current.split('_')[0] | lower }}"
     funct_type: "{{ function_list.sap_control_function_current.split('_')[1] | lower }}"
+    sorted_sap_facts: []
 
 - name: Prepare - Set header
   ansible.builtin.set_fact:


### PR DESCRIPTION
The bugfix contains just 1 line to initialise the varable holding the sorted sap facts to avoid reusing an already sorted content.

<img width="1145" height="179" alt="image" src="https://github.com/user-attachments/assets/fb285aec-fcd2-4a63-a24d-fc1f562003ea" />

This should now fit with the former merges